### PR TITLE
9.10UI改动2

### DIFF
--- a/JChat/src/io/jchat/android/activity/ChatActivity.java
+++ b/JChat/src/io/jchat/android/activity/ChatActivity.java
@@ -273,23 +273,23 @@ public class ChatActivity extends BaseActivity {
                 UserInfo userInfo = groupInfo.getGroupMemberInfo(JMessageClient.getMyInfo().getUserName());
                 //如果自己在群聊中，同时显示群人数
                 if (userInfo != null){
-                    if (TextUtils.isEmpty(data.getStringExtra(JPushDemoApplication.GROUP_NAME))) {
+                    if (TextUtils.isEmpty(data.getStringExtra(JPushDemoApplication.NAME))) {
                         mChatView.setChatTitle(this.getString(R.string.group),
                                 data.getIntExtra("currentCount", 0), mDensityDpi);
                     } else {
-                        mChatView.setChatTitle(data.getStringExtra(JPushDemoApplication.GROUP_NAME),
+                        mChatView.setChatTitle(data.getStringExtra(JPushDemoApplication.NAME),
                                 data.getIntExtra("currentCount", 0), mDensityDpi);
                     }
                 }else {
-                    if (TextUtils.isEmpty(data.getStringExtra(JPushDemoApplication.GROUP_NAME))) {
+                    if (TextUtils.isEmpty(data.getStringExtra(JPushDemoApplication.NAME))) {
                         mChatView.setChatTitle(this.getString(R.string.group), mDensityDpi);
                     } else {
-                        mChatView.setChatTitle(data.getStringExtra(JPushDemoApplication.GROUP_NAME),
+                        mChatView.setChatTitle(data.getStringExtra(JPushDemoApplication.NAME),
                                 mDensityDpi);
                     }
                 }
 
-            }
+            }else mChatView.setChatTitle(data.getStringExtra(JPushDemoApplication.NAME), mDensityDpi);
             if (data.getBooleanExtra("deleteMsg", false)){
                 mChatController.getAdapter().clearMsgList();
             }

--- a/JChat/src/io/jchat/android/activity/ChatDetailActivity.java
+++ b/JChat/src/io/jchat/android/activity/ChatDetailActivity.java
@@ -194,7 +194,7 @@ public class ChatDetailActivity extends BaseActivity {
     public void onBackPressed() {
         Log.i(TAG, "onBackPressed");
         Intent intent = new Intent();
-        intent.putExtra(JPushDemoApplication.GROUP_NAME, mChatDetailController.getGroupName());
+        intent.putExtra(JPushDemoApplication.NAME, mChatDetailController.getName());
         intent.putExtra("currentCount", mChatDetailController.getCurrentCount());
         intent.putExtra("deleteMsg", mChatDetailController.getDeleteFlag());
         setResult(JPushDemoApplication.RESULT_CODE_CHAT_DETAIL, intent);

--- a/JChat/src/io/jchat/android/activity/FriendInfoActivity.java
+++ b/JChat/src/io/jchat/android/activity/FriendInfoActivity.java
@@ -169,4 +169,13 @@ public class FriendInfoActivity extends BaseActivity {
             });
         }
     }
+
+    @Override
+    public void onBackPressed() {
+        Intent intent = new Intent();
+        intent.putExtra(JPushDemoApplication.NICKNAME, mNickname);
+        setResult(JPushDemoApplication.RESULT_CODE_FRIEND_INFO, intent);
+        finish();
+        super.onBackPressed();
+    }
 }

--- a/JChat/src/io/jchat/android/application/JPushDemoApplication.java
+++ b/JChat/src/io/jchat/android/application/JPushDemoApplication.java
@@ -27,6 +27,7 @@ public class JPushDemoApplication extends Application {
     private static final String JCHAT_CONFIGS = "JChat_configs";
 
     public static final String TARGET_ID = "targetID";
+    public static final String NAME = "name";
     public static final String NICKNAME = "nickname";
     public static final String GROUP_ID = "groupID";
     public static final String IS_GROUP = "isGroup";

--- a/JChat/src/io/jchat/android/controller/ChatDetailController.java
+++ b/JChat/src/io/jchat/android/controller/ChatDetailController.java
@@ -121,7 +121,7 @@ public class ChatDetailController implements OnClickListener, OnItemClickListene
         } else {
             Conversation conv = JMessageClient.getSingleConversation(mTargetID);
             mCurrentNum = 1;
-            mGridAdapter = new GroupMemberGridAdapter(mContext, mTargetID, conv.getTitle());
+            mGridAdapter = new GroupMemberGridAdapter(mContext, mTargetID);
             mChatDetailView.setAdapter(mGridAdapter);
             // 设置单聊界面
             mChatDetailView.setSingleView();
@@ -143,7 +143,7 @@ public class ChatDetailController implements OnClickListener, OnItemClickListene
             case R.id.return_btn:
                 Intent intent = new Intent();
                 intent.putExtra("deleteMsg", mDeleteMsg);
-                intent.putExtra(JPushDemoApplication.GROUP_NAME, getGroupName());
+                intent.putExtra(JPushDemoApplication.NAME, getName());
                 intent.putExtra("currentCount", mCurrentNum);
                 mContext.setResult(JPushDemoApplication.RESULT_CODE_CHAT_DETAIL, intent);
                 mContext.finish();
@@ -575,8 +575,13 @@ public class ChatDetailController implements OnClickListener, OnItemClickListene
         return true;
     }
 
-    public String getGroupName() {
-        return mGroupName;
+    public String getName() {
+        if (mIsGroup){
+            return mGroupName;
+        }else {
+            Conversation conv = JMessageClient.getSingleConversation(mTargetID);
+            return ((UserInfo)conv.getTargetInfo()).getNickname();
+        }
     }
 
     public int getCurrentCount() {


### PR DESCRIPTION
1.修复在聊天界面中点击成员头像查看好友资料后，返回聊天界面，聊天标题不更新的bug
2.修复在单聊的聊天详情界面点击好友头像查看好友资料后，返回聊天
详情界面，好友资料以及聊天标题不更新的bug

Signed-off-by: KenChoi1992 <992649726@qq.com>