### PR TITLE
9.22UI改动

### DIFF
--- a/JChat/src/io/jchat/android/activity/ChatActivity.java
+++ b/JChat/src/io/jchat/android/activity/ChatActivity.java
@@ -345,7 +345,9 @@ public class ChatActivity extends BaseActivity {
                                 mChatView.dismissRightBtn();
                                 GroupInfo groupInfo = (GroupInfo)mChatController.getConversation()
                                         .getTargetInfo();
-                                mChatView.setChatTitle(groupInfo.getGroupName());
+                                if (TextUtils.isEmpty(groupInfo.getGroupName())){
+                                    mChatView.setChatTitle(ChatActivity.this.getString(R.string.group));
+                                }else mChatView.setChatTitle(groupInfo.getGroupName());
                                 mChatView.dismissGroupNum();
                             }
                         });

--- a/JChat/src/io/jchat/android/activity/ChatDetailActivity.java
+++ b/JChat/src/io/jchat/android/activity/ChatDetailActivity.java
@@ -275,6 +275,7 @@ public class ChatDetailActivity extends BaseActivity {
 
     public void startChatActivity(long groupID, String groupName) {
         Intent intent = new Intent();
+        intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         intent.putExtra("isGroup", true);
         //设置跳转标志
         intent.putExtra("fromGroup", true);

--- a/JChat/src/io/jchat/android/adapter/MsgListAdapter.java
+++ b/JChat/src/io/jchat/android/adapter/MsgListAdapter.java
@@ -988,7 +988,14 @@ public class MsgListAdapter extends BaseAdapter {
                         customContent.setBooleanValue("blackList", true);
                         Message customMsg = mConv.createSendMessage(customContent);
                         addMsgToList(customMsg);
-                    } else HandleResponseCode.onHandle(mContext, status, false);
+                    } else {
+                        HandleResponseCode.onHandle(mContext, status, false);
+                        holder.sendingIv.clearAnimation();
+                        holder.sendingIv.setVisibility(View.GONE);
+                        holder.picture.setAlpha(1.0f);
+                        holder.progressTv.setVisibility(View.GONE);
+                        holder.resend.setVisibility(View.VISIBLE);
+                    }
                 }
             });
         }

--- a/JChat/src/io/jchat/android/controller/ChatDetailController.java
+++ b/JChat/src/io/jchat/android/controller/ChatDetailController.java
@@ -4,7 +4,6 @@ import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Intent;
 import android.graphics.Bitmap;
-import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
 import android.text.TextUtils;
@@ -20,18 +19,21 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
-import cn.jpush.im.android.eventbus.EventBus;
-import io.jchat.android.R;
+
 import java.io.File;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
-import cn.jpush.im.android.api.model.Conversation;
-import cn.jpush.im.android.api.model.GroupInfo;
+
 import cn.jpush.im.android.api.JMessageClient;
-import cn.jpush.im.android.api.model.UserInfo;
 import cn.jpush.im.android.api.callback.CreateGroupCallback;
 import cn.jpush.im.android.api.callback.GetUserInfoCallback;
+import cn.jpush.im.android.api.model.Conversation;
+import cn.jpush.im.android.api.model.GroupInfo;
+import cn.jpush.im.android.api.model.UserInfo;
+import cn.jpush.im.android.eventbus.EventBus;
+import cn.jpush.im.api.BasicCallback;
+import io.jchat.android.R;
 import io.jchat.android.activity.ChatDetailActivity;
 import io.jchat.android.activity.FriendInfoActivity;
 import io.jchat.android.activity.MeInfoActivity;
@@ -39,11 +41,10 @@ import io.jchat.android.adapter.GroupMemberGridAdapter;
 import io.jchat.android.application.JPushDemoApplication;
 import io.jchat.android.entity.Event;
 import io.jchat.android.tools.BitmapLoader;
+import io.jchat.android.tools.DialogCreator;
 import io.jchat.android.tools.HandleResponseCode;
 import io.jchat.android.tools.NativeImageLoader;
 import io.jchat.android.view.ChatDetailView;
-import io.jchat.android.tools.DialogCreator;
-import cn.jpush.im.api.BasicCallback;
 
 public class ChatDetailController implements OnClickListener, OnItemClickListener, OnItemLongClickListener {
 
@@ -119,7 +120,6 @@ public class ChatDetailController implements OnClickListener, OnItemClickListene
             }
             // 是单聊
         } else {
-            Conversation conv = JMessageClient.getSingleConversation(mTargetID);
             mCurrentNum = 1;
             mGridAdapter = new GroupMemberGridAdapter(mContext, mTargetID);
             mChatDetailView.setAdapter(mGridAdapter);

--- a/JChat/src/io/jchat/android/view/MeView.java
+++ b/JChat/src/io/jchat/android/view/MeView.java
@@ -15,14 +15,12 @@ import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
-import io.jchat.android.R;
-
 import java.io.File;
 import java.lang.ref.WeakReference;
 
 import cn.jpush.im.android.api.JMessageClient;
 import cn.jpush.im.android.api.model.UserInfo;
-
+import io.jchat.android.R;
 import io.jchat.android.tools.BitmapLoader;
 
 public class MeView extends LinearLayout {
@@ -117,8 +115,8 @@ public class MeView extends LinearLayout {
         Thread thread = new Thread(new Runnable() {
             @Override
             public void run() {
-                Bitmap bmp = BitmapLoader.doBlur(bitmap, false);
-                if (null != bmp) {
+                if (bitmap != null){
+                    Bitmap bmp = BitmapLoader.doBlur(bitmap, false);
                     android.os.Message msg = myHandler.obtainMessage();
                     msg.obj = bmp;
                     msg.sendToTarget();


### PR DESCRIPTION
1.修复群名为空时，被踢的成员聊天标题为空的bug 
2.修复发送图片失败时，发送状态不更新的bug
3.修复“我”界面加载头像时，可能报NPE的bug
4.从单聊创建群聊，intent增加标志：FLAG_ACTIVITY_CLEAR_TOP，避免出现
多个聊天界面