### PR TITLE
11.10改动

### DIFF
--- a/JChat/res/values/strings.xml
+++ b/JChat/res/values/strings.xml
@@ -280,7 +280,7 @@
     <string name="sdk_87x_871310">网络已断开，请检查网络连接</string>
     <string name="sdk_87x_871311">用户未设定头像，下载头像失败</string>
     <string name="sdk_87x_871312">ImageContent创建失败</string>
-    <string name="sdk_87x_871403">发送失败，请稍后重试</string>
+    <string name="sdk_87x_871403">第三方上传失败，请稍后重试</string>
     <string name="sdk_87x_871404">下载失败，请稍后重试</string>
     <string name="sdk_87x_871501">appkey与appid不匹配或者token无效</string>
     <string name="sdk_87x_871502">appkey无效</string>

--- a/JChat/src/io/jchat/android/activity/BaseActivity.java
+++ b/JChat/src/io/jchat/android/activity/BaseActivity.java
@@ -62,7 +62,7 @@ public class BaseActivity extends Activity {
                 intent.putExtra("userName", myInfo.getUserName());
                 File avatar = myInfo.getAvatarFile();
                 if (null != avatar && avatar.exists()) {
-                    intent.putExtra("userAvatar", avatar.getAbsolutePath());
+                    intent.putExtra("avatarFilePath", avatar.getAbsolutePath());
                 }
                 Log.i(TAG, "userName " + myInfo.getUserName());
                 JMessageClient.logout();

--- a/JChat/src/io/jchat/android/activity/BaseFragment.java
+++ b/JChat/src/io/jchat/android/activity/BaseFragment.java
@@ -64,7 +64,7 @@ public class BaseFragment extends Fragment {
                 intent.putExtra("userName", myInfo.getUserName());
                 File avatar = myInfo.getAvatarFile();
                 if (null != avatar && avatar.exists()) {
-                    intent.putExtra("userAvatar", avatar.getAbsolutePath());
+                    intent.putExtra("avatarFilePath", avatar.getAbsolutePath());
                 }
                 Log.i(TAG, "userName " + myInfo.getUserName());
                 JMessageClient.logout();

--- a/JChat/src/io/jchat/android/activity/ChatActivity.java
+++ b/JChat/src/io/jchat/android/activity/ChatActivity.java
@@ -368,12 +368,18 @@ public class ChatActivity extends BaseActivity {
                     String targetID = ((UserInfo) msg.getTargetInfo()).getUserName();
                     //判断消息是否在当前会话中
                     if (!mChatController.isGroup() && targetID.equals(mChatController.getTargetID())) {
-                        mChatController.getAdapter().addMsgToList(msg);
+                        Message lastMsg = mChatController.getConversation().getLatestMessage();
+                        if (lastMsg == null || msg.getId() != lastMsg.getId()) {
+                            mChatController.getAdapter().addMsgToList(msg);
+                        }
                     }
                 }else {
                     long groupID = ((GroupInfo)msg.getTargetInfo()).getGroupID();
                     if (mChatController.isGroup() && groupID == mChatController.getGroupId()) {
-                        mChatController.getAdapter().addMsgToList(msg);
+                        Message lastMsg = mChatController.getConversation().getLatestMessage();
+                        if (lastMsg == null || msg.getId() != lastMsg.getId()) {
+                            mChatController.getAdapter().addMsgToList(msg);
+                        }
                     }
                 }
             }

--- a/JChat/src/io/jchat/android/activity/FixProfileActivity.java
+++ b/JChat/src/io/jchat/android/activity/FixProfileActivity.java
@@ -22,13 +22,11 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.Toast;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-
 import cn.jpush.im.android.api.JMessageClient;
 import cn.jpush.im.android.api.model.UserInfo;
 import cn.jpush.im.api.BasicCallback;
@@ -36,6 +34,7 @@ import io.jchat.android.R;
 import io.jchat.android.application.JPushDemoApplication;
 import io.jchat.android.tools.BitmapLoader;
 import io.jchat.android.tools.DialogCreator;
+import io.jchat.android.tools.HandleResponseCode;
 import io.jchat.android.tools.SharePreferenceManager;
 import io.jchat.android.view.CircleImageView;
 
@@ -43,6 +42,8 @@ import io.jchat.android.view.CircleImageView;
  * Created by Ken on 2015/1/26.
  */
 public class FixProfileActivity extends BaseActivity {
+
+    private static final String TAG = "FixProfileActivity";
 
     private Button mFinishBtn;
     private EditText mNickNameEt;
@@ -239,6 +240,12 @@ public class FixProfileActivity extends BaseActivity {
         } else if (requestCode == JPushDemoApplication.REQUEST_CODE_CROP_PICTURE) {
             //裁剪后得到返回的bitmap
             Bitmap bitmap = decodeUriAsBitmap(mUri);
+            File file = new File(mUri.getPath());
+            if (file.isFile()) {
+                if (file.delete()) {
+                    Log.d(TAG, "delete temp file success!");
+                }
+            }
             String path = BitmapLoader.saveBitmapToLocal(bitmap, this);
             uploadUserAvatar(path);
         }
@@ -352,19 +359,19 @@ public class FixProfileActivity extends BaseActivity {
                     mDialog.dismiss();
                 }
                 if (status == 0) {
-                    Log.i("FixProfileActivity", "Update avatar succeed path " + path);
+                    Log.i(TAG, "Update avatar succeed path " + path);
                     loadUserAvatar(path);
                     Toast.makeText(FixProfileActivity.this,
                             FixProfileActivity.this.getString(R.string.avatar_modify_succeed_toast),
                             Toast.LENGTH_SHORT).show();
                 } else {
-                    Toast.makeText(FixProfileActivity.this, desc, Toast.LENGTH_SHORT).show();
+                    HandleResponseCode.onHandle(mContext, status, false);
                 }
                 //删除裁剪后的文件
                 File file = new File(path);
                 if (file.isFile()) {
                     if (file.delete()) {
-                        Log.d("FixProfileActivity", "delete temp file : " + path);
+                        Log.d(TAG, "delete temp file : " + path);
                     }
                 }
             }
@@ -374,9 +381,9 @@ public class FixProfileActivity extends BaseActivity {
     private void loadUserAvatar(String path) {
         final Bitmap bitmap = BitmapLoader.getBitmapFromFile(path, (int) (100 * mDensity),
                 (int) (100 * mDensity));
-        Log.i("FixProfileActivity", "bitmap.getWidth() bitmap.getHeight() " + bitmap.getWidth()
+        Log.i(TAG, "bitmap.getWidth() bitmap.getHeight() " + bitmap.getWidth()
                 + bitmap.getHeight());
-        Log.i("FixProfileActivity", "file path " + path);
+        Log.i(TAG, "file path " + path);
         mAvatarIv.setImageBitmap(bitmap);
     }
 

--- a/JChat/src/io/jchat/android/activity/FixProfileActivity.java
+++ b/JChat/src/io/jchat/android/activity/FixProfileActivity.java
@@ -212,7 +212,18 @@ public class FixProfileActivity extends BaseActivity {
                     Cursor cursor = this.getContentResolver()
                             .query(selectedImg, filePathColumn, null, null, null);
                     try {
-                        if (null == cursor || !cursor.moveToFirst()) {
+                        if (null == cursor) {
+                            String path = selectedImg.getPath();
+                            File file = new File(path);
+                            if (file.isFile()) {
+                                copyAndCrop(file);
+                                return;
+                            }else {
+                                Toast.makeText(this, this.getString(R.string.picture_not_found),
+                                        Toast.LENGTH_SHORT).show();
+                                return;
+                            }
+                        }else if (!cursor.moveToFirst()) {
                             Toast.makeText(this, this.getString(R.string.picture_not_found),
                                     Toast.LENGTH_SHORT).show();
                             return;

--- a/JChat/src/io/jchat/android/activity/MainActivity.java
+++ b/JChat/src/io/jchat/android/activity/MainActivity.java
@@ -15,13 +15,11 @@ import android.support.v4.app.FragmentManager;
 import android.text.TextUtils;
 import android.util.Log;
 import android.widget.Toast;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-
 import cn.jpush.android.api.JPushInterface;
 import cn.jpush.im.android.api.JMessageClient;
 import io.jchat.android.R;

--- a/JChat/src/io/jchat/android/activity/MainActivity.java
+++ b/JChat/src/io/jchat/android/activity/MainActivity.java
@@ -117,7 +117,18 @@ public class MainActivity extends FragmentActivity{
                     String[] filePathColumn = { MediaStore.Images.Media.DATA };
                     Cursor cursor = this.getContentResolver()
                             .query(selectedImg, filePathColumn, null, null, null);
-                    if (null == cursor || !cursor.moveToFirst()) {
+                    if (null == cursor) {
+                        String path = selectedImg.getPath();
+                        File file = new File(path);
+                        if (file.isFile()) {
+                            copyAndCrop(file);
+                            return;
+                        }else {
+                            Toast.makeText(this, this.getString(R.string.picture_not_found),
+                                    Toast.LENGTH_SHORT).show();
+                            return;
+                        }
+                    }else if (!cursor.moveToFirst()) {
                         Toast.makeText(this, this.getString(R.string.picture_not_found),
                                 Toast.LENGTH_SHORT).show();
                         return;

--- a/JChat/src/io/jchat/android/activity/PickPictureActivity.java
+++ b/JChat/src/io/jchat/android/activity/PickPictureActivity.java
@@ -118,6 +118,7 @@ public class PickPictureActivity extends BaseActivity {
                     else {
                         mDialog = new ProgressDialog(PickPictureActivity.this);
                         mDialog.setCanceledOnTouchOutside(false);
+                        mDialog.setCancelable(false);
                         mDialog.setMessage(PickPictureActivity.this.getString(R.string.sending_hint));
                         mDialog.show();
 


### PR DESCRIPTION
1.填写资料界面删除剪裁图片时复制的图片
2.871403描述更改
3.发送图片时，将不能点击返回键取消发送对话框
4.修复被踢下线后，在重新登录界面没有显示用户头像的bug 
5.修复上传头像时，如果用户选择通过文件管理上传，不能成功上传
头像的bug
6.在聊天界面收到消息增加判断该消息是否已经存在于该会话